### PR TITLE
PMT #113305 Search bug

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,17 +1,30 @@
 {
     "env": {
-        "browser": true
+        "browser": true,
+        "amd": true,
+        "jquery": true
     },
-    "extends": "eslint:recommended",
+    "plugins": [
+        "security",
+        "scanjs-rules",
+        "no-unsafe-innerhtml"
+    ],
+    "extends": [
+        "eslint:recommended",
+        "plugin:security/recommended"
+    ],  
     "rules": {
         "indent": [
             "error",
-            4,
-            {"SwitchCase": 1}
+            4
         ],
         "linebreak-style": [
             "error",
             "unix"
+        ],
+        "no-unused-vars": [
+            "error",
+            {"vars": "all", "args": "none"}
         ],
         "quotes": [
             "error",
@@ -20,6 +33,64 @@
         "semi": [
             "error",
             "always"
-        ]
+        ],
+        "max-len": [2, {"code": 80, "tabWidth": 4, "ignoreUrls": true}],
+        "space-before-function-paren": ["error", "never"],
+        "space-in-parens": ["error", "never"],
+        "no-trailing-spaces": ["error"],
+        "key-spacing": ["error", { "beforeColon": false }],
+        "func-call-spacing": ["error", "never"],
+
+        /** no-unsafe-innerhtml rule **/
+        "no-unsafe-innerhtml/no-unsafe-innerhtml" : 2,
+
+        /** ScanJS rules **/
+        "scanjs-rules/assign_to_hostname": 1,
+        "scanjs-rules/assign_to_href": 1,
+        "scanjs-rules/assign_to_location": 1,
+        "scanjs-rules/assign_to_onmessage": 1,
+        "scanjs-rules/assign_to_pathname": 1,
+        "scanjs-rules/assign_to_protocol": 1,
+        "scanjs-rules/assign_to_search": 1,
+        "scanjs-rules/assign_to_src": 1,
+        "scanjs-rules/call_Function": 1,
+        "scanjs-rules/call_addEventListener": 1,
+        "scanjs-rules/call_addEventListener_deviceproximity": 1,
+        "scanjs-rules/call_addEventListener_message": 1,
+        "scanjs-rules/call_connect": 1,
+        "scanjs-rules/call_eval": 1,
+        "scanjs-rules/call_execScript": 1,
+        "scanjs-rules/call_hide": 0, /* hide used often. overly cautious */
+        "scanjs-rules/call_open_remote=true": 1,
+        "scanjs-rules/call_parseFromString": 1,
+        "scanjs-rules/call_setImmediate": 1,
+        "scanjs-rules/call_setInterval": 1,
+        "scanjs-rules/call_setTimeout": 1,
+        "scanjs-rules/identifier_indexedDB": 1,
+        "scanjs-rules/identifier_localStorage": 1,
+        "scanjs-rules/identifier_sessionStorage": 1,
+        "scanjs-rules/new_Function": 1,
+        "scanjs-rules/property_addIdleObserver": 1,
+        "scanjs-rules/property_createContextualFragment": 1,
+        "scanjs-rules/property_geolocation": 1,
+        "scanjs-rules/property_getUserMedia": 1,
+        "scanjs-rules/property_indexedDB": 1,
+        "scanjs-rules/property_localStorage": 1,
+        "scanjs-rules/property_mgmt": 1,
+        "scanjs-rules/property_sessionStorage": 1,
+
+        "security/detect-buffer-noassert": 1,
+        "security/detect-child-process": 1,
+        "security/detect-disable-mustache-escape": 1,
+        "security/detect-eval-with-expression": 1,
+        "security/detect-new-buffer": 1,
+        "security/detect-no-csrf-before-method-override": 1,
+        "security/detect-non-literal-fs-filename": 1,
+        "security/detect-non-literal-regexp": 1,
+        "security/detect-non-literal-require": 0, /* requirejs conflict */
+        "security/detect-object-injection": 0, /* several false positives */
+        "security/detect-possible-timing-attacks": 1,
+        "security/detect-pseudoRandomBytes": 1,
+        "security/detect-unsafe-regex": 1
     }
 }

--- a/assets/js/src/search.js
+++ b/assets/js/src/search.js
@@ -95,14 +95,37 @@ if (typeof require === 'function') {
                     searchParams.push(param.toLowerCase());
                 }
             });
-        }).filter(function(result) {
-            var hasSomeParams =
-                Object.keys(result.matchData.metadata).length
-                === searchParams.length;
-            return searchParams.join('') === '*' || hasSomeParams;
         });
 
         var me = this;
+        this.results = this.results.filter(function(r) {
+            var d = me.data[r.ref];
+
+            // If there is a param and a result doesn't have that param
+            // then filter it out.
+            if (params[1]) {
+                if (!d.climate_topics.includes(params[1])) {
+                    return false;
+                }
+            }
+            if (params[2]) {
+                if (!d.polar_topics.includes(params[2])) {
+                    return false;
+                }
+            }
+            if (params[3]) {
+                if (!d.resource_type.includes(params[3])) {
+                    return false;
+                }
+            }
+            if (params[4]) {
+                if (!d.audience.includes(params[4])) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
         this.results.forEach(function(r) {
             var d = me.data[r.ref];
             var href = '../resources/' + slugify(d.title);

--- a/assets/js/src/search.js
+++ b/assets/js/src/search.js
@@ -96,8 +96,9 @@ if (typeof require === 'function') {
                 }
             });
         }).filter(function(result) {
-            var hasSomeParams = Object.keys(result.matchData.metadata).length ===
-                searchParams.length;
+            var hasSomeParams =
+                Object.keys(result.matchData.metadata).length
+                === searchParams.length;
             return searchParams.join('') === '*' || hasSomeParams;
         });
 
@@ -180,9 +181,10 @@ if (typeof require === 'function') {
 
     if (typeof document === 'object') {
         $(document).ready(function() {
-            var loaderAnimation = '<div id="loader-animation-container" class="col-12">' +
-                                  '<div class="loader-inner ball-pulse"><div></div><div></div><div></div></div>' +
-                                  '</div>';
+            var loaderAnimation =
+                '<div id="loader-animation-container" class="col-12">' +
+                '<div class="loader-inner ball-pulse"><div></div><div>' +
+                '</div><div></div></div></div>';
 
             $('#search-results').append(loaderAnimation);
             var path = window.location.pathname.replace(/database\/$/, '');
@@ -233,7 +235,8 @@ if (typeof require === 'function') {
                     useAnchors: false,
                     cssStyle: 'light-theme',
                     onPageClick: function(pageNumber) {
-                        if (search.results.length > 0 || $('#q').val().length > 0) {
+                        if (search.results.length > 0 ||
+                                $('#q').val().length > 0) {
                             refreshEvents(search.results, pageNumber);
                         } else {
                             refreshEvents(search.results, pageNumber);
@@ -255,7 +258,8 @@ if (typeof require === 'function') {
                     });
 
                     $('#q').val(searchString);
-                    window.history.replaceState(null, '', window.location.pathname);
+                    window.history.replaceState(null, '',
+                        window.location.pathname);
                 }
 
                 search.doSearch([searchString,'','']);
@@ -274,7 +278,8 @@ if (typeof require === 'function') {
                     refreshEvents(search.results, 1);
                 });
 
-                $('select#formClimateTopics,select#formPolarTopics,select#formResourceType,select#formAudience')
+                $('select#formClimateTopics,select#formPolarTopics,' +
+                     'select#formResourceType,select#formAudience')
                     .change(function() {
                         clearSearch();
                         search.doSearch([

--- a/assets/js/tests/test-search.js
+++ b/assets/js/tests/test-search.js
@@ -51,10 +51,13 @@ describe('Search.doSearch()', function() {
         assert.strictEqual(s.results.length, 0);
 
         s.doSearch(['US Global Change', null, null, null, null]);
-        assert.strictEqual(s.results.length, 45);
+        assert.strictEqual(s.results.length, 186);
 
         s.doSearch(['', null, 'Arctic', null, null]);
         assert.strictEqual(s.results.length, 136);
+
+        s.doSearch(['coastal arctic food web', null, null, null, null]);
+        assert.strictEqual(s.results[0].ref, "A Coastal Arctic Food Web");
     });
 
     it('can search on multiple facets', function() {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "homepage": "https://github.com/ccnmtl/polarhub#readme",
   "devDependencies": {
     "eslint": "~4.13.0",
+    "eslint-plugin-no-unsafe-innerhtml": "^1.0.16",
+    "eslint-plugin-scanjs-rules": "^0.2.1",
+    "eslint-plugin-security": "^1.4.0",
     "jquery": "~3.2.1",
     "jsdom": "~11.5.1",
     "lunr": "~2.1.2",


### PR DESCRIPTION
When searching for a string of words that mostly matched a known title,
the expected result would not appear. This was caused by a hack used to
to get Lunr to handle fields as facets, which it can not do. I convinced
myself of this fact after several hours of reading, and re-reading the
Lunr docs.

Rather, the fix filters out items that don't have the specified tag. The
tests have been updated to specifically test for the bug in this PMT.