### PR TITLE
PMT #114394: Fix search in Safari

### DIFF
--- a/assets/js/lib/lunr.js
+++ b/assets/js/lib/lunr.js
@@ -1810,9 +1810,15 @@ lunr.Index.prototype.query = function (fn) {
          * For each term get the posting and termIndex, this is required for
          * building the query vector.
          */
-        var expandedTerm = expandedTerms[j],
-            posting = this.invertedIndex[expandedTerm],
-            termIndex = posting._index
+         /* This hamhanded expression is a workaround for a mysterious
+          * bug in Safari: https://github.com/olivernn/lunr.js/issues/279
+          */
+         if (navigator.userAgent.indexOf('Safari') !== -1) {
+             console.log(expandedTerms[j]);
+         }
+        var expandedTerm = expandedTerms[j];
+        var posting = this.invertedIndex[expandedTerm];
+        var termIndex = posting._index;
 
         for (var k = 0; k < clause.fields.length; k++) {
           /*


### PR DESCRIPTION
LunrJS has some undefined behavoir in Safari, documented here:
https://github.com/olivernn/lunr.js/issues/279

This workaround console-logs out the terms which seems to slow down things
enough for it to work, suggesting a race condition somewhere. As this is
a bug with either Safari or LunrJS, we'll have to wait for them to sort
it out.